### PR TITLE
Make example working without MA57

### DIFF
--- a/examples/example1.cpp
+++ b/examples/example1.cpp
@@ -308,7 +308,7 @@ int main( int argc, const char* argv[] )
     // 0: full space Hessian approximation (ignore block structure), 1: blockwise updates
     opts->blockHess = 0;
     opts->whichSecondDerv = 0;
-    opts->sparseQP = 2;
+    opts->sparseQP = 1;
     opts->printLevel = 2;
 
 


### PR DESCRIPTION
Thanks for making this code available! I have been looking for a free SQP-Implementation for a long time!

Right now the example uses qpOASES with the Schur complement approach, which is not available without MA57 installed. By using `dense factorization of red. Hessian`, the examples runs even with a simple qpOASES.

Signed-off-by: Matthias Kümmerer matthias@matthias-k.org
