### PR TITLE
Fix missing virtual destructor

### DIFF
--- a/examples/example1.cpp
+++ b/examples/example1.cpp
@@ -308,7 +308,7 @@ int main( int argc, const char* argv[] )
     // 0: full space Hessian approximation (ignore block structure), 1: blockwise updates
     opts->blockHess = 0;
     opts->whichSecondDerv = 0;
-    opts->sparseQP = 2;
+    opts->sparseQP = 1;
     opts->printLevel = 2;
 
 

--- a/include/blocksqp_matrix.hpp
+++ b/include/blocksqp_matrix.hpp
@@ -46,7 +46,7 @@ class Matrix
       Matrix( int = 1, int = 1, int = -1 );                         ///< constructor with standard arguments
       Matrix( int, int, double*, int = -1 );
       Matrix( const Matrix& A );
-      ~Matrix( void );
+      virtual ~Matrix( void );
 
       int M( void ) const;                                          ///< number of rows
       int N( void ) const;                                          ///< number of columns
@@ -96,7 +96,7 @@ class SymMatrix : public Matrix
         SymMatrix( int, int, double*, int = -1 );
         SymMatrix( const Matrix& A );
         SymMatrix( const SymMatrix& A );
-        ~SymMatrix( void );
+        virtual ~SymMatrix( void );
 
         virtual double &operator()( int i, int j );
         virtual double &operator()( int i, int j ) const;


### PR DESCRIPTION
The `Matrix` class uses a non-virtual destructor, nevertheless it is used as base class for `SymMatrix`. This results in undefined behaviour [(see here)](http://stackoverflow.com/questions/12994920/how-to-delete-an-object-of-a-polymorphic-class-type-that-has-no-virtual-destruct). I changed the declaration of `~Matrix` and `~SymMatrix` to be virtual, which makes the warnings about undefined behaviour in my code go away.
